### PR TITLE
Update JWT config file to use .env secret

### DIFF
--- a/config/jwt.php
+++ b/config/jwt.php
@@ -25,7 +25,7 @@ return [
     |
     */
 
-    'secret' => 'my-dummy-jwt-token',
+    'secret' => env('JWT_SECRET', 'my-dummy-jwt-token'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
For some reason, JWT config file was not set for using the .env defined secret.