### PR TITLE
Fix composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,10 @@
             "php artisan jwt:secret -f"
         ],
         "post-install-cmd": [
-            "Illuminate\\Foundation\\ComposerScripts::postInstall",
-            "php artisan optimize"
+            "Illuminate\\Foundation\\ComposerScripts::postInstall"
         ],
         "post-update-cmd": [
-            "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-            "php artisan optimize"
+            "Illuminate\\Foundation\\ComposerScripts::postUpdate"
         ]
     },
     "config": {


### PR DESCRIPTION
Laravel 5.6 Will Remove the Artisan Optimize Command
https://laravel-news.com/laravel-5-6-removes-artisan-optimize